### PR TITLE
Track upstream branch of sc2reader instead of fixed commit.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,10 +20,7 @@ MySQL-python
 pyyaml
 Pillow
 
-#file:///Users/david/Dropbox/Programming/sc2reader/sc2reader#egg=sc2reader
-#-e git://github.com/ggtracker/sc2reader.git#egg=sc2reader
--e git://github.com/ggtracker/sc2reader.git@504fff2ed926c206b9aa74c70bbc017bb7c40718#egg=sc2reader
-#-e git://github.com/nickelsen/sc2reader.git@5e6e235fa399dc691519d38faa11d71667b69002#egg=sc2reader
+-e git://github.com/ggtracker/sc2reader.git@upstream#egg=sc2reader
 
 enum34
 


### PR DESCRIPTION
I'm thinking to track `upstream` instead of a commit for the sake of easier development (avoids a commit to ggpyjobs after merging to sc2reader `upstream`).

@dsjoerg Would this be possible from a operational point of view in production? The risk I want to avoid is that new content is pulled from `upstream` during operation or deploy without ggpyjobs being synced. If this is not ok, we'll just go back to tracking commits, to always have everything synced and locked in explicitly.
